### PR TITLE
シリアライザーの作成

### DIFF
--- a/backend/question_control/questions/models.py
+++ b/backend/question_control/questions/models.py
@@ -26,6 +26,7 @@ class AnswerFavorite(models.Model):
     answer = models.ForeignKey(Answer, on_delete=models.CASCADE)
     like = models.BooleanField(
         verbose_name='いいね',
+        default=False
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/backend/question_control/questions/serializers.py
+++ b/backend/question_control/questions/serializers.py
@@ -1,0 +1,43 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+from .models import Question, Answer, AnswerFavorite
+from rest_framework.authtoken.models import Token
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email', 'password')
+        extra_kwargs = {'password': {'write_only': True, 'required': True}}
+
+    # パスワードをハッシュ化するためオーバーライド
+    def create(self, validated_data):
+        user = User.objects.create_user(**validated_data)
+        Token.objects.create(user=user)
+        return user
+
+class QuestionSerializer(serializers.ModelSerializer):
+
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+
+    class Meta:
+        model = Question
+        fields = ('id', 'question_text', 'created_at', 'updated_at')
+
+class AnswerSerializer(serializers.ModelSerializer):
+
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+
+    class Meta:
+        model = Answer
+        fields = ('id', 'answer_text', 'created_at', 'updated_at')
+
+class AnswerFavoriteSerializer(serializers.ModelSerializer):
+
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+    updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M", read_only=True)
+
+    class Meta:
+        model = Answer
+        fields = ('id', 'like', 'created_at', 'updated_at')


### PR DESCRIPTION
# What

### serializersを作成
- ユーザー作成のリクエスト時、パスワードをハッシュ化するためにcreateメソッドをオーバーライドして作成しました。
- パスワードは書き込みのみ可能に設定しました。
- レスポンス時、時間の出力のフォーマットを設定しました。

### modelsの設定を変更
AnswerFavoriteモデルのlinkフィールドのデフォルト値をFalseにしました。